### PR TITLE
Adds windows_dc_restore, windows_gdi_select_object_nullptr which restores previous HGDIOBJ in device context

### DIFF
--- a/unique_rc/CMakeLists.txt
+++ b/unique_rc/CMakeLists.txt
@@ -18,7 +18,9 @@ set(HEADERS
   ${CMAKE_CURRENT_LIST_DIR}/inc/deleter/windows_com_release.hpp
   ${CMAKE_CURRENT_LIST_DIR}/inc/deleter/windows_com_file_dlg_unadvise.hpp
   ${CMAKE_CURRENT_LIST_DIR}/inc/deleter/windows_gdi_deleter.hpp
+  ${CMAKE_CURRENT_LIST_DIR}/inc/deleter/windows_gdi_select_object.hpp
   ${CMAKE_CURRENT_LIST_DIR}/inc/deleter/windows_dc_deleter.hpp
+  ${CMAKE_CURRENT_LIST_DIR}/inc/deleter/windows_dc_restore.hpp
   ${CMAKE_CURRENT_LIST_DIR}/inc/deleter/windows_close_handle.hpp
 )
 

--- a/unique_rc/inc/deleter/windows_dc_restore.hpp
+++ b/unique_rc/inc/deleter/windows_dc_restore.hpp
@@ -1,0 +1,32 @@
+#ifndef WIN_GDI_DC_RESTORE_HPP
+#define WIN_GDI_DC_RESTORE_HPP
+
+#include "raii_defs.hpp"
+
+#include <concepts>
+#include <cstddef>
+#include <windows.h>
+
+
+RAII_NS_BEGIN
+
+
+// Restores device context (DC) state obtained with SaveDC
+// nullptr indicates invalid dc
+struct gdi_restore_dc_nullptr
+{
+  raii_inline constexpr gdi_restore_dc_nullptr(int state) noexcept : state_{ state } {}
+
+  [[nodiscard]] raii_inline static constexpr std::nullptr_t invalid() noexcept { return nullptr; }
+
+  // constexpr generates error - constexpr function doesn't evaluate at compile time
+  raii_inline void operator()(HDC h) const noexcept { RestoreDC(h, state_); }
+
+private:
+  int state_;
+};
+
+
+RAII_NS_END
+
+#endif// WIN_GDI_DC_RESTORE_HPP

--- a/unique_rc/inc/deleter/windows_gdi_select_object.hpp
+++ b/unique_rc/inc/deleter/windows_gdi_select_object.hpp
@@ -1,0 +1,36 @@
+#ifndef WIN_GDI_SELECT_OBJECT_HPP
+#define WIN_GDI_SELECT_OBJECT_HPP
+
+#include "raii_defs.hpp"
+
+#include <concepts>
+#include <cstddef>
+#include <windows.h>
+
+
+RAII_NS_BEGIN
+
+// Selects GDI objects such as pen, brush, bitmap, etc.
+// nullptr indicates invalid object
+template<typename Handle>
+  requires std::convertible_to<Handle, HGDIOBJ>
+struct gdi_select_object_nullptr
+{
+  constexpr gdi_select_object_nullptr(HDC hdc) noexcept : hdc_{ hdc } {}
+
+  template<typename U>
+  raii_inline constexpr gdi_select_object_nullptr(const gdi_select_object_nullptr<U> &) noexcept
+    requires std::is_convertible_v<U, Handle>
+  {}
+
+  [[nodiscard]] raii_inline static constexpr std::nullptr_t invalid() noexcept { return nullptr; }
+
+  raii_inline constexpr void operator()(Handle h) const noexcept { SelectObject(hdc_, h); }
+
+private:
+  HDC hdc_;
+};
+
+RAII_NS_END
+
+#endif// WIN_GDI_SELECT_OBJECT_HPP

--- a/unique_rc/src/unique_rc.cpp
+++ b/unique_rc/src/unique_rc.cpp
@@ -9,7 +9,9 @@
 #include "windows_com_file_dlg_unadvise.hpp"
 #include "windows_com_release.hpp"
 #include "windows_dc_deleter.hpp"
+#include "windows_dc_restore.hpp"
 #include "windows_gdi_deleter.hpp"
+#include "windows_gdi_select_object.hpp"
 
 #endif
 // NOLINTEND(misc-include-cleaner)


### PR DESCRIPTION
Adds windows_dc_restore, windows_gdi_select_object_nullptr which restores previous HGDIOBJ in device context