### PR TITLE
Fixes unique_rc/ptr construction from l-value reference deleter. Test…

### DIFF
--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -40,6 +40,7 @@ set(TESTS_HEADERS
 set(TESTS_SOURCES
   ${CMAKE_CURRENT_SOURCE_DIR}/unique_ptr_tests.cpp
 
+  ${CMAKE_CURRENT_SOURCE_DIR}/${TEST_SOURCE_PREFIX}/assignment/forward_deleter.cpp
   ${CMAKE_CURRENT_SOURCE_DIR}/${TEST_SOURCE_PREFIX}/assignment/deleter_inheritance.cpp
   ${CMAKE_CURRENT_SOURCE_DIR}/${TEST_SOURCE_PREFIX}/assignment/move_array.cpp
   ${CMAKE_CURRENT_SOURCE_DIR}/${TEST_SOURCE_PREFIX}/assignment/move_single.cpp

--- a/test/src/assignment/forward_deleter.cpp
+++ b/test/src/assignment/forward_deleter.cpp
@@ -1,0 +1,59 @@
+#include <catch2/catch_test_macros.hpp>
+
+#include "unique_ptr.hpp"
+
+#include <cstddef>// std::nullptr_t
+#include <utility>
+
+namespace {
+struct CopyAssignDeleter
+{
+  CopyAssignDeleter() = default;
+  ~CopyAssignDeleter() = default;
+
+  CopyAssignDeleter(const CopyAssignDeleter &) = default;
+  CopyAssignDeleter(CopyAssignDeleter &&) = default;
+
+  // NOLINTNEXTLINE(cert-oop54-cpp) false poisitive
+  CopyAssignDeleter &operator=(const CopyAssignDeleter & /*unused*/) noexcept
+  {
+    CHECK(true);
+    return *this;
+  }
+
+  CopyAssignDeleter &operator=(CopyAssignDeleter && /*unused*/) noexcept
+  {
+    CHECK(false);
+    return *this;
+  }
+
+  template<class T> void operator()(T * /*unused*/) const noexcept {}
+
+  [[nodiscard]] static constexpr std::nullptr_t invalid() noexcept { return {}; }
+
+  template<class T> [[nodiscard]] static constexpr bool is_owned(T *ptr) noexcept
+  {
+    return static_cast<bool>(ptr);
+  }
+};
+
+struct DerivedCopyAssignDeleter : CopyAssignDeleter
+{
+};
+}// namespace
+
+
+TEST_CASE("unique_ptr move assignment forwards deleter", "[unique_ptr][unique_ptr::unique_ptr]")
+{
+  CopyAssignDeleter baseDeleter;
+
+  // NOLINTNEXTLINE(readability-isolate-declaration)
+  raii::unique_ptr<int, CopyAssignDeleter &> ptr1{ nullptr, baseDeleter }, ptr2{ nullptr, baseDeleter };
+  ptr2 = std::move(ptr1);
+
+  DerivedCopyAssignDeleter derivedDeleter;
+
+  // NOLINTNEXTLINE
+  raii::unique_ptr<int[], CopyAssignDeleter &> aptr1{ nullptr, derivedDeleter }, aptr2{ nullptr, derivedDeleter };
+  aptr2 = std::move(aptr1);
+}


### PR DESCRIPTION
…s l-value deleter is forwarded when unique_ptr/rc is move assigned