### PR TITLE
Fixes TypeResolver in unique_rc constraint, removes using handle = po…

### DIFF
--- a/test/src/hash/hash.cpp
+++ b/test/src/hash/hash.cpp
@@ -52,7 +52,7 @@ TEST_CASE("Test hash with empty pointer type", "[unique_ptr][hash]")
       // NOLINTNEXTLINE(hicpp-explicit-conversions)
       pointer(std::nullptr_t) {};
     };
-    void operator()([[maybe_unused]] pointer ptr) const noexcept {}
+    void operator()(pointer /*unused*/) const noexcept {}
   };
 
   STATIC_CHECK_FALSE(is_callable_v<std::hash<D::pointer> &, D::pointer>);
@@ -79,13 +79,12 @@ struct D
     bool operator!=(std::nullptr_t) const { return true; }
   };
 
-  using handle = pointer;
 
   [[nodiscard]] static constexpr std::nullptr_t invalid() noexcept { return nullptr; }
 
-  [[nodiscard]] static constexpr bool is_owned([[maybe_unused]] pointer ptr) noexcept { return true; }
+  [[nodiscard]] static constexpr bool is_owned(pointer /*unused*/) noexcept { return true; }
 
-  void operator()([[maybe_unused]] pointer ptr) const noexcept {}
+  void operator()(pointer /*unused*/) const noexcept {}
 };
 
 struct F
@@ -96,13 +95,12 @@ struct F
     bool operator!=(std::nullptr_t) const { return true; }
   };
 
-  using handle = pointer;
 
   [[nodiscard]] static constexpr pointer invalid() noexcept { return {}; }
 
-  [[nodiscard]] static constexpr bool is_owned([[maybe_unused]] pointer ptr) noexcept { return true; }
+  [[nodiscard]] static constexpr bool is_owned(pointer /*unused*/) noexcept { return true; }
 
-  void operator()([[maybe_unused]] pointer ptr) const noexcept {}
+  void operator()(pointer /*unused*/) const noexcept {}
 };
 
 }// namespace
@@ -111,17 +109,17 @@ namespace std {
 template<> struct hash<D::pointer>
 {
   // NOLINTNEXTLINE(hicpp-exception-baseclass)
-  std::size_t operator()([[maybe_unused]] D::pointer ptr) const { throw 1; }
+  std::size_t operator()(D::pointer /*unused*/) const { throw 1; }
 };
 
 template<> struct hash<F::pointer>
 {
   // NOLINTNEXTLINE(hicpp-exception-baseclass)
-  std::size_t operator()([[maybe_unused]] F::pointer ptr) const { throw 3; }
+  std::size_t operator()(F::pointer /*unused*/) const { throw 3; }
 };
 }// namespace std
 
-TEST_CASE("Test hash operator() throw", "[unique_ptr][hash][throw]")
+TEST_CASE("hash::operator() throws with Deleter::pointer type", "[unique_ptr][hash][throw]")
 {
   using UP = raii::unique_ptr<int, D>;
   const UP ptr1;

--- a/test/src/io/lwg2948.cpp
+++ b/test/src/io/lwg2948.cpp
@@ -31,16 +31,15 @@ template<typename> struct deleter
     constexpr pointer() = default;
     explicit pointer(std::nullptr_t) {}
     explicit operator bool() const { return false; }
-    bool operator==([[maybe_unused]] pointer ptr) const { return true; }
+    bool operator==(pointer /*unused*/) const { return true; }
   };
 
-  using handle = pointer;
 
   static constexpr pointer invalid() noexcept { return {}; }
 
-  static constexpr bool is_owned([[maybe_unused]] const pointer &ptr) noexcept { return false; }
+  static constexpr bool is_owned(pointer /*unused*/) noexcept { return false; }
 
-  void operator()([[maybe_unused]] pointer ptr) const {}
+  void operator()(pointer /*unused*/) const {}
 };
 
 

--- a/test/src/requirements/dr2228.cpp
+++ b/test/src/requirements/dr2228.cpp
@@ -9,7 +9,7 @@
 
 struct do_nothing
 {
-  template<class T> void operator()([[maybe_unused]] T *ptr) const noexcept {}
+  template<class T> void operator()(T * /*unused*/) const noexcept {}
 };
 
 TEST_CASE("DR 2228 is not assignable unique_rc", "[unique_rc::operator=]")

--- a/test/src/specialised_algorithms/constexpr_swap.cpp
+++ b/test/src/specialised_algorithms/constexpr_swap.cpp
@@ -18,7 +18,7 @@ struct B
   static constexpr std::nullptr_t invalid() noexcept;
   static constexpr bool is_owned(void *) noexcept;
 
-  void operator()([[maybe_unused]] void *ptr) const {}
+  void operator()(void * /*unused*/) const {}
 };
 // NOLINTEND(cppcoreguidelines-special-member-functions, hicpp-special-member-functions)
 
@@ -27,7 +27,7 @@ void swap(B &, B &) = delete;
 // NOLINTBEGIN(cppcoreguidelines-special-member-functions, hicpp-special-member-functions)
 struct C
 {
-  void operator()([[maybe_unused]] void *ptr) const {}
+  void operator()(void * /*unused*/) const {}
 };
 // NOLINTEND(cppcoreguidelines-special-member-functions, hicpp-special-member-functions)
 
@@ -38,7 +38,7 @@ struct D
 {
   D(D &&) = delete;
 
-  void operator()([[maybe_unused]] void *ptr) const {}
+  void operator()(void * /*unused*/) const {}
 };
 
 struct NoSwapPtr
@@ -62,7 +62,7 @@ struct NoSwapPtr
   static constexpr pointer invalid() noexcept;
   static constexpr bool is_owned(pointer) noexcept;
 
-  void operator()([[maybe_unused]] pointer ptr) const noexcept {}
+  void operator()(pointer /*unused*/) const noexcept {}
 };
 
 }// namespace

--- a/unique_rc/inc/unique_rc.hpp
+++ b/unique_rc/inc/unique_rc.hpp
@@ -214,7 +214,7 @@ struct unique_rc_holder<Handle, Deleter, TypeResolver, false, false>
 // because it is impossible to distinguish a pointer obtained from array and non - array forms of new.
 template<typename Handle, class Deleter, template<typename, typename> typename TypeResolver = resolve_handle_type>
   requires has_static_invalid_convertible_handle<std::remove_reference_t<Deleter>,
-    typename resolve_handle_type<std::decay_t<Handle>, std::remove_reference_t<Deleter>>::type>
+    typename TypeResolver<std::decay_t<Handle>, std::remove_reference_t<Deleter>>::type>
 class unique_rc
 {
   static_assert(!std::is_array_v<Handle>, "unique_rc does not work with array, use raii::unique_ptr");


### PR DESCRIPTION
…inter in unique_ptr tests. Replaces [[maybe_unused]] parameter name attribute with /*unused*/