### PR TITLE
Bumps up cmake minimum version to 3.30. Adds RemovedArgs to clang-tid…

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -17,6 +17,13 @@ Checks: "*,
         -misc-use-anonymous-namespace,
         -misc-use-internal-linkage
 "
+# Cannot filter by regex, therefore hardcoded whole argument
+RemovedArgs: 
+  - '-fdeps-format=p1689r5'
+  - '-fmodule-mapper=sample_app/CMakeFiles/sample_app.dir/src/main.cpp.o.modmap'
+  - '-fmodules-ts'
+
+
 WarningsAsErrors: ''
 HeaderFilterRegex: ''
 FormatStyle:     none

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.23)
+cmake_minimum_required(VERSION 3.30)
 
 # Only set the cxx_standard if it is not set by someone else
 if(NOT DEFINED CMAKE_CXX_STANDARD)

--- a/cmake/Sanitizers.cmake
+++ b/cmake/Sanitizers.cmake
@@ -78,7 +78,6 @@ function(
           )
         endif()
         target_compile_options(${project_name} INTERFACE /fsanitize=${LIST_OF_SANITIZERS} /Zi /INCREMENTAL:NO)
-        target_compile_definitions(${project_name} INTERFACE _DISABLE_VECTOR_ANNOTATION _DISABLE_STRING_ANNOTATION)
         target_link_options(${project_name} INTERFACE /INCREMENTAL:NO)
       endif()
     endif()

--- a/sample_app/CMakeLists.txt
+++ b/sample_app/CMakeLists.txt
@@ -13,20 +13,26 @@ set(SAMPLE_APP_SOURCES
 
 set(EXEC_TARGET sample_app)
 
-add_executable(${EXEC_TARGET} ${SAMPLE_APP_HEADERS} ${SAMPLE_APP_SOURCES})
+add_executable(${EXEC_TARGET})
+
+target_sources(${EXEC_TARGET} 
+              PRIVATE ${SAMPLE_APP_HEADERS} 
+                      ${SAMPLE_APP_SOURCES}
+)
 
 # Request minimum c++ standard, default c++20
 target_compile_features(${EXEC_TARGET} PUBLIC cxx_std_23)
 
-target_link_libraries(${EXEC_TARGET} PRIVATE 
-                  myproject::myproject_options
-                  myproject::myproject_warnings
-                  urc::urc)
+target_link_libraries(${EXEC_TARGET} 
+              PRIVATE myproject::myproject_options
+                      myproject::myproject_warnings
+                      urc::urc
+)
 
 target_link_system_libraries(${EXEC_TARGET} PRIVATE 
                                             CLI11::CLI11
                                             fmt::fmt
                                             # spdlog::spdlog
-                            )
+)
 
 target_include_directories(${EXEC_TARGET} PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/inc ${CMAKE_BINARY_DIR}/configured_files/include)

--- a/test/src/creation/for_overwrite.cpp
+++ b/test/src/creation/for_overwrite.cpp
@@ -77,6 +77,7 @@ TEST_CASE("raii::make_unique_for_overwrite via malloc with memset non-trivial ty
   struct NonTrivial
   {
     int init = constInitMem;
+    // cppcheck-suppress uninitMemberVarNoCtor;
     int uninit;
   };
 

--- a/unique_rc/CMakeLists.txt
+++ b/unique_rc/CMakeLists.txt
@@ -12,10 +12,19 @@ function(add_lib_interface lib_name)
   #cmake_print_variables(PROJECT_SOURCE_DIR)
   #cmake_print_variables(CMAKE_CURRENT_LIST_DIR)
 
-  target_include_directories(${lib_name} ${WARNING_GUARD} INTERFACE 
-                                $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
-                                $<BUILD_INTERFACE:${PROJECT_BINARY_DIR}/include>
-                                $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>)
+  target_sources(${lib_name} ${WARNING_GUARD}
+    INTERFACE
+    FILE_SET HEADERS
+    BASE_DIRS ./include
+    FILES include/urc/raii_defs.hpp
+          include/urc/concepts.hpp
+          include/urc/coroutine_destroy.hpp
+          include/urc/memory_delete.hpp
+          include/urc/stdio_fclose.hpp
+
+          include/urc/unique_rc.hpp
+          include/urc/unique_ptr.hpp
+  )
 endfunction()
 
 
@@ -23,7 +32,6 @@ add_lib_interface(urc)
 add_library(urc::urc ALIAS urc)
 
 #urc library uses c++ 20 which is set via myproject::myproject_options
-# target_compile_features(urc PUBLIC cxx_std_20)
 
 
 #generate_export_header(unique_rc EXPORT_FILE_NAME ${PROJECT_BINARY_DIR}/unique_rc/include/unique_rc_export.hpp)


### PR DESCRIPTION
…y, specific to gcc. Migrate to target_sources() with FILE_SET. Removes disable annotations for address sanitiser MSVC